### PR TITLE
Use first argument as branch name

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -42,6 +42,9 @@ nvm_ls_current() {
   fi
 }
 
+# First argument is supposed to be selected branch name
+branch=${1:-'stable'}
+
 case "`nvm_ls_current`" in
 "system")
     sudo='sudo'
@@ -60,18 +63,20 @@ wait
 
 (
     cd sealious
-    git checkout next
+    git checkout $branch
     npm install
     $sudo npm link
     git remote set-url origin ssh://git@github.com/Sealious/sealious
 
     cd ../sealious-www-server
+    git checkout $branch
     npm install
     npm link sealious
     $sudo npm link
     git remote set-url origin ssh://git@github.com/Sealious/sealious-www-server
 
     cd ../sealious-channel-rest
+    git checkout $branch
     npm install
     npm link sealious
     npm link sealious-www-server


### PR DESCRIPTION
Script first argument is name of branch to switch. Defaults to 'stable'. It has no effect on 'hello-world' repo, since it's being maintained only in master branch. New one-liner call method:

`curl https://raw.githubusercontent.com/Sealious/sealious/next/dev-setup.sh | sh -s <branch>`

where "\<branch\>" is selected branch name. Shell's '-s' parameter is supported by Dash, Bash and AFAIK Zsh.