### PR TITLE
Make the plugin manager a little bit more verbose

### DIFF
--- a/lib/plugins/plugin-manager.js
+++ b/lib/plugins/plugin-manager.js
@@ -7,8 +7,10 @@ var PluginManager = new function(){
 		dir = dir || "";
 		var root = path.resolve(dir);
 		var pkgfile = path.join(root, 'package.json');
+		Sealious.Logger.info(`Checking '${pkgfile} for Sealious plugins...`)
 		var pkg = require(pkgfile);
 
+		var found_any_plugins = false;
 		for (var dependency_name in pkg.dependencies){
 			var plugin_package_info_file = path.resolve(root, "node_modules", dependency_name, "package.json");
 			try {
@@ -17,12 +19,16 @@ var PluginManager = new function(){
 				continue;
 			}
 			if (plugin_package_info.keywords && plugin_package_info.keywords.indexOf("sealious-plugin")!==-1){
-				Sealious.Logger.info("Detected plugin " + plugin_package_info.name);
+				Sealious.Logger.info("	\u2713 found plugin " + plugin_package_info.name);
+				found_any_plugins = true;
 				var plugin_dir = path.resolve(root, "node_modules", dependency_name);
 				var plugin = require(path.resolve(root, "node_modules", dependency_name));
 				load_plugins_from_dir(plugin_dir);
 			}
-		}		
+		}
+		if (!found_any_plugins){
+			Sealious.Logger.info("  No plugins found.")
+		}
 	}
 
 	this.load_plugins = function(){

--- a/lib/plugins/plugin-manager.js
+++ b/lib/plugins/plugin-manager.js
@@ -7,7 +7,7 @@ var PluginManager = new function(){
 		dir = dir || "";
 		var root = path.resolve(dir);
 		var pkgfile = path.join(root, 'package.json');
-		Sealious.Logger.info(`Checking '${pkgfile} for Sealious plugins...`)
+		Sealious.Logger.info("Checking " + pkgfile + " for Sealious plugins...");
 		var pkg = require(pkgfile);
 
 		var found_any_plugins = false;


### PR DESCRIPTION
I recently stumbled upon some issues with debugging the way Sealious handles plugin detection, so I added logging to Plugin Manager. 