### PR TITLE
Issue#257 error on put for bad

### DIFF
--- a/lib/chip-types/resource-type.js
+++ b/lib/chip-types/resource-type.js
@@ -182,8 +182,10 @@ ResourceType.prototype = new function(){
 		var promises = {};
 		for (var field_name in body){
 			var current_value = body[field_name];
-			var old_value = old_body && old_body[field_name];
-			promises[field_name] = this.fields[field_name].encode_value(context, current_value, old_value);
+			if (current_value !== undefined){
+				var old_value = old_body && old_body[field_name];
+				promises[field_name] = this.fields[field_name].encode_value(context, current_value, old_value);				
+			}
 		}
 		return Promise.props(promises);
 	}

--- a/tests/unit-tests/resource-type.test.js
+++ b/tests/unit-tests/resource-type.test.js
@@ -1,0 +1,34 @@
+var Sealious = require("sealious");
+
+var has_bar_field;
+
+module.exports = {
+	test_init: function(){
+		new Sealious.ChipTypes.FieldType({
+			name: "encode_to_bar",
+			extends: "text",
+			encode: function(){
+				return "bar"
+			}
+		})
+
+		has_bar_field = new Sealious.ChipTypes.ResourceType({
+			name: "has_bar_field",
+			fields: [{name: "bar", type: "encode_to_bar"}]
+		})
+	},
+	test_start: function(){
+		describe("ResourceType", function(){
+			it("should not run 'encode' for missing/undefined field values", function(done){
+				has_bar_field.encode_field_values(new Sealious.Context(), {bar: undefined})
+				.then(function(encoded_body){
+					if(encoded_body.bar=="bar"){
+						done(new Error());
+					}else{
+						done();
+					}
+				})
+			})
+		})
+	}
+}


### PR DESCRIPTION
In case of some of the `body` variable attributes in the `ResourceType.encode_field_values` method being set to undefined, like so:
```
body = {foo: undefined}
```

the `encode_field_values` method executed `FieldType.encode_values` with `undedined` as a parameter. I've added a check in that method that prevents that from happening.

This should only be merged to 0.6 branch