### PR TITLE
Make the Plugin Manager output easier to read

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.12"
+  - "4.3.1"
 script: npm install && npm test
 after_success:
 - npm run coveralls

--- a/lib/plugins/plugin-manager.js
+++ b/lib/plugins/plugin-manager.js
@@ -45,7 +45,7 @@ var PluginManager = new function(){
 				var plugin_dir = path.resolve(plugin_info_path, "../");
 				load_plugins_from_dir(plugin_dir);
 				require(resolve.sync(plugin_name, {basedir: root}));
-				Sealious.Logger.info("\t\u2713 ${plugin_name}")
+				Sealious.Logger.info(`\t\u2713 ${plugin_name}`)
 			}
 		}
 	}

--- a/lib/plugins/plugin-manager.js
+++ b/lib/plugins/plugin-manager.js
@@ -5,26 +5,26 @@ var resolve = require("resolve");
 
 var PluginManager = new function(){
 
-	function get_package_info_path(dir, package_name){
+	function get_package_info_path (dir, package_name) {
 		var package_path = resolve.sync(package_name, { basedir: dir });
 		var package_info_path = null;
-		while(package_info_path==null){
+		while (package_info_path==null){
 			var temp_path = path.resolve(package_path, "../package.json");
 			try {
-			    fs.accessSync(temp_path, fs.F_OK);
-			    package_info_path = temp_path;
+				fs.accessSync(temp_path, fs.F_OK);
+				package_info_path = temp_path;
 			} catch (e) {
-			    package_path = path.resolve(package_path, "../");
+				package_path = path.resolve(package_path, "../");
 			}
 		}
 		return package_info_path;
 	}
 
-	function get_package_info(dir, package_name){
+	function get_package_info (dir, package_name) {
 		return require(get_package_info_path(dir, package_name));
 	}
 
-	function is_sealious_plugin(dir, module_name){
+	function is_sealious_plugin (dir, module_name) {
 		var plugin_package_info = get_package_info(dir, module_name);
 		return plugin_package_info.keywords && plugin_package_info.keywords.indexOf("sealious-plugin")!==-1;
 	}
@@ -37,15 +37,15 @@ var PluginManager = new function(){
 		var dependencies = pkg.dependencies;
 		var required_sealious_plugins = Object.keys(dependencies).filter(is_sealious_plugin.bind({}, root));
 
-		if(required_sealious_plugins.length){
-			Sealious.Logger.debug(`${pkg.name} (${pkgfile}) requires: ${required_sealious_plugins.join(", ")}`)
-			for(var i in required_sealious_plugins){
+		if (required_sealious_plugins.length){
+			Sealious.Logger.debug(pkg.name + " (" + pkgfile + ") requires: " + required_sealious_plugins.join(", "))
+			for (var i in required_sealious_plugins){
 				var plugin_name = required_sealious_plugins[i];
 				var plugin_info_path = get_package_info_path(root, plugin_name);
 				var plugin_dir = path.resolve(plugin_info_path, "../");
 				load_plugins_from_dir(plugin_dir);
 				require(resolve.sync(plugin_name, {basedir: root}));
-				Sealious.Logger.info(`\t\u2713 ${plugin_name}`)
+				Sealious.Logger.info("\t\u2713 ${plugin_name}")
 			}
 		}
 	}

--- a/lib/plugins/plugin-manager.js
+++ b/lib/plugins/plugin-manager.js
@@ -1,44 +1,62 @@
 var Sealious = require("../main.js");
 var path = require("path");
+var fs = require("fs");
+var resolve = require("resolve");
 
 var PluginManager = new function(){
 
-	function load_plugins_from_dir (dir) {
-		dir = dir || "";
-		var root = path.resolve(dir);
-		var pkgfile = path.join(root, 'package.json');
-		Sealious.Logger.info("Checking " + pkgfile + " for Sealious plugins...");
-		var pkg = require(pkgfile);
-
-		var found_any_plugins = false;
-		for (var dependency_name in pkg.dependencies){
-			var plugin_package_info_file = path.resolve(root, "node_modules", dependency_name, "package.json");
+	function get_package_info_path(dir, package_name){
+		var package_path = resolve.sync(package_name, { basedir: dir });
+		var package_info_path = null;
+		while(package_info_path==null){
+			var temp_path = path.resolve(package_path, "../package.json");
 			try {
-				var plugin_package_info = require(plugin_package_info_file);				
-			} catch (error){
-				continue;
-			}
-			if (plugin_package_info.keywords && plugin_package_info.keywords.indexOf("sealious-plugin")!==-1){
-				Sealious.Logger.info("	\u2713 found plugin " + plugin_package_info.name);
-				found_any_plugins = true;
-				var plugin_dir = path.resolve(root, "node_modules", dependency_name);
-				var plugin = require(path.resolve(root, "node_modules", dependency_name));
-				load_plugins_from_dir(plugin_dir);
+			    fs.accessSync(temp_path, fs.F_OK);
+			    package_info_path = temp_path;
+			} catch (e) {
+			    package_path = path.resolve(package_path, "../");
 			}
 		}
-		if (!found_any_plugins){
-			Sealious.Logger.info("  No plugins found.")
+		return package_info_path;
+	}
+
+	function get_package_info(dir, package_name){
+		return require(get_package_info_path(dir, package_name));
+	}
+
+	function is_sealious_plugin(dir, module_name){
+		var plugin_package_info = get_package_info(dir, module_name);
+		return plugin_package_info.keywords && plugin_package_info.keywords.indexOf("sealious-plugin")!==-1;
+	}
+
+	function load_plugins_from_dir (dir) {
+		var root = path.resolve(dir);
+		var pkgfile = path.join(root, 'package.json');
+		var pkg = require(pkgfile);
+
+		var dependencies = pkg.dependencies;
+		var required_sealious_plugins = Object.keys(dependencies).filter(is_sealious_plugin.bind({}, root));
+
+		if(required_sealious_plugins.length){
+			Sealious.Logger.debug(`${pkg.name} (${pkgfile}) requires: ${required_sealious_plugins.join(", ")}`)
+			for(var i in required_sealious_plugins){
+				var plugin_name = required_sealious_plugins[i];
+				var plugin_info_path = get_package_info_path(root, plugin_name);
+				var plugin_dir = path.resolve(plugin_info_path, "../");
+				load_plugins_from_dir(plugin_dir);
+				require(resolve.sync(plugin_name, {basedir: root}));
+				Sealious.Logger.info(`\t\u2713 ${plugin_name}`)
+			}
 		}
 	}
 
 	this.load_plugins = function(){
-		load_plugins_from_dir("");
-
+		Sealious.Logger.info("Loading plugins...");
 		var sealious_dir = path.resolve(module.filename, "../../../");
 		if (sealious_dir!=path.resolve("")){
-			load_plugins_from_dir(sealious_dir);			
+			load_plugins_from_dir(sealious_dir);
 		}
-
+		load_plugins_from_dir("");
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "immutable": "^3.7.2",
     "merge": "^1.2.0",
     "require-dir": "^0.3.0",
+    "resolve": "^1.1.7",
     "sanitize-html": "^1.6.1",
     "sealious-datastore-tingo": "^0.1.5",
     "sha1": "^1.1.0",


### PR DESCRIPTION
I've used the `resolve` package to make the PluginManager behave correctly when used on an app with `npm link`-ed Sealious plugins. 

Now the PluginManager's output is separated into `info` and `debug` messages, to make them more readable. 

PluginManager's output before this commit:

```
11:34:53.973 - info: Checking /home/arkadiusz/Projects/Placetag/package.json for Sealious plugins...
11:34:53.994 - info:    ✓ found plugin sealious-channel-rest
11:34:54.710 - info: Checking /home/arkadiusz/Projects/Placetag/node_modules/sealious-channel-rest/package.json for Sealious plugins...
11:34:54.711 - info:   No plugins found.
11:34:54.712 - info:    ✓ found plugin sealious-datastore-mongo
{ [Error: Cannot find module '../build/Release/bson'] code: 'MODULE_NOT_FOUND' }
js-bson: Failed to load c++ bson extension, using pure JS version
11:34:54.863 - info: Checking /home/arkadiusz/Projects/Placetag/node_modules/sealious-datastore-mongo/package.json for Sealious plugins...
11:34:54.864 - info:   No plugins found.
11:34:54.865 - info:    ✓ found plugin sealious-www-server
11:34:54.865 - info: Checking /home/arkadiusz/Projects/Placetag/node_modules/sealious-www-server/package.json for Sealious plugins...
11:34:54.867 - info:   No plugins found.
11:34:54.868 - info: Checking /home/arkadiusz/Projects/Placetag/node_modules/sealious/package.json for Sealious plugins...
11:34:54.872 - info:    ✓ found plugin sealious-datastore-tingo
11:34:54.983 - info: Checking /home/arkadiusz/Projects/Placetag/node_modules/sealious/node_modules/sealious-datastore-tingo/package.json for Sealious plugins...
```

After, Logger set up to `debug` level:

```
19:18:07.436 - info: Loading plugins...
19:18:07.460 - debug: sealious (/home/kuba/projects/Sealious/sealious/package.json) requires: sealious-datastore-tingo
19:18:07.543 - info: 	✓ sealious-datastore-tingo
19:18:07.615 - debug: placetag-app (/home/kuba/temp/Placetag/package.json) requires: sealious-channel-rest, sealious-datastore-mongo, sealious-www-server
19:18:07.616 - debug: sealious-channel-rest (/home/kuba/temp/Placetag/node_modules/sealious-channel-rest/package.json) requires: sealious-www-server
19:18:08.236 - info: 	✓ sealious-www-server
19:18:08.238 - info: 	✓ sealious-channel-rest
{ [Error: Cannot find module '../build/Release/bson'] code: 'MODULE_NOT_FOUND' }
js-bson: Failed to load c++ bson extension, using pure JS version
19:18:08.353 - info: 	✓ sealious-datastore-mongo
19:18:08.357 - info: 	✓ sealious-www-server
```

And after with `info` debug level:

```
19:18:07.436 - info: Loading plugins...
19:18:07.543 - info: 	✓ sealious-datastore-tingo
19:18:08.236 - info: 	✓ sealious-www-server
19:18:08.238 - info: 	✓ sealious-channel-rest
{ [Error: Cannot find module '../build/Release/bson'] code: 'MODULE_NOT_FOUND' }
js-bson: Failed to load c++ bson extension, using pure JS version
19:18:08.353 - info: 	✓ sealious-datastore-mongo
19:18:08.357 - info: 	✓ sealious-www-server
```